### PR TITLE
Added limit on query to sender_retry_queue on retry-route

### DIFF
--- a/distribution/sender/routes/retry-route.xml
+++ b/distribution/sender/routes/retry-route.xml
@@ -5,7 +5,7 @@
 
         <log message="Fetching events in the retry queue" loggingLevel="DEBUG" />
 
-        <toD uri="jpa:SenderRetryQueueItem?query=SELECT r.id FROM SenderRetryQueueItem r ORDER BY r.dateCreated ASC, r.id ASC" />
+        <toD uri="jpa:SenderRetryQueueItem?query=SELECT r.id FROM SenderRetryQueueItem r ORDER BY r.dateCreated ASC, r.id ASC&amp;maximumResults=1000" />
 
         <choice>
             <when>


### PR DESCRIPTION
In this branch was resolved the issue discribed in [this jira ticket](https://jira.fgh.org.mz/browse/EC-169)